### PR TITLE
add number response in chat/message creation body

### DIFF
--- a/chat-system-app/app/controllers/chats_controller.rb
+++ b/chat-system-app/app/controllers/chats_controller.rb
@@ -32,7 +32,7 @@ class ChatsController < ApplicationController
     end
 
     CreateChatJob.perform_later(token, chat_number)
-    render json: { chat_number: chat_number }, status: :created
+    render json: { chat_number: chat_number, number: chat_number }, status: :created
   end
 
   # PATCH/PUT /chats/1

--- a/chat-system-app/app/controllers/messages_controller.rb
+++ b/chat-system-app/app/controllers/messages_controller.rb
@@ -47,7 +47,7 @@ class MessagesController < ApplicationController
     end
 
     CreateMessageJob.perform_later(token, chat_number, message_number, body)
-    render json: { message_number: message_number }, status: :created
+    render json: { message_number: message_number, number: message_number }, status: :created
   end
 
   # PATCH/PUT /applications/{application_token}/chats/{chat_number}/messages/{number}

--- a/creation-webserver/main.go
+++ b/creation-webserver/main.go
@@ -54,6 +54,7 @@ func createChat(c *gin.Context) {
 	}
 	jsonResponse := map[string]interface{}{
 		"chat_number": chatNumber,
+		"number":      chatNumber,
 	}
 
 	jobId := AddJob(QUEUE_CHATS, time.Now(), token, chatNumber)
@@ -80,6 +81,7 @@ func createMessage(c *gin.Context) {
 	}
 	jsonResponse := map[string]interface{}{
 		"message_number": messageNumber,
+		"number":         messageNumber,
 	}
 
 	jobId := AddJob(QUEUE_MESSAGES, time.Now(), token, chatNumber, messageNumber, body)


### PR DESCRIPTION
- leave 'chat_number' and 'message_number' for backwards compatibility and descriptiveness